### PR TITLE
Add missing dependency to the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ export-hook 1.0.0 is Scala 2.11.7 supported via the macro paradise compiler plug
 scalaVersion := "2.11.7"
 
 libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
   "org.typelevel" %% "export-hook" % "1.0.2",
   compilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full)
 )


### PR DESCRIPTION
A dependency on scala-reflect is required for the sample code to compile.

See [this](https://gitter.im/milessabin/export-hook?at=5639d2a9c74a90c744792f4c) gitter conversation with @milessabin.
