### PR TITLE
Switch to OpenJDK in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
 - 2.13.0-RC1
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 cache:
   directories:


### PR DESCRIPTION
Travis would otherwise fail because OracleJDK stopped working in Xenial.